### PR TITLE
Handle errors and support Windows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,4 @@ readme = "README.md"
 
 [dependencies]
 isatty = "0.1.1"
-
-[target."cfg(unix)".dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
This removes the use of process piping, and instead relies
on the temp file to run rustfmt and pygmentize.

Fixes #7 and #23.