### PR TITLE
Disable reorderings in rustfmt

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -8,11 +8,15 @@ use crate::error::Result;
 #[derive(Serialize)]
 struct Rustfmt {
     normalize_doc_attributes: bool,
+    reorder_imports: bool,
+    reorder_modules: bool,
 }
 
 pub fn write_rustfmt_config(outdir: impl AsRef<Path>) -> Result<()> {
     let config = Rustfmt {
         normalize_doc_attributes: true,
+        reorder_imports: false,
+        reorder_modules: false,
     };
 
     let toml_string = toml::to_string(&config)?;


### PR DESCRIPTION
Fixes #56. Currently blocked on https://github.com/rust-lang/rustfmt/issues/3515.