### PR TITLE
support expand.color setting in cargo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ To expand a specific module or type or function only:
 ## Configuration
 
 The cargo expand command reads the `[expand]` section of $CARGO_HOME/config if
-there is one (usually ~/.cargo/config). Currently the only configuration option
-is the syntax highlighting theme.
+there is one (usually ~/.cargo/config).
+
+Set the default syntax highlighting theme with the `theme` setting:
 
 ```toml
 [expand]
@@ -117,6 +118,14 @@ theme = "TwoDark"
 
 Run `cargo expand --themes` to print a list of available themes. Use `theme =
 "none"` to disable coloring.
+
+Change the default coloring disposition (normally `auto`) with the `color`
+setting:
+
+```toml
+[expand]
+color = "always"
+```
 
 ## Disclaimer
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ struct Sections {
 #[derive(Deserialize, Default)]
 pub struct Config {
     pub theme: Option<String>,
+    pub color: Option<String>,
 }
 
 pub fn deserialize() -> Config {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -115,7 +115,7 @@ pub struct Args {
     pub item: Option<Selector>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Coloring {
     Auto,
     Always,


### PR DESCRIPTION
Fixes #76 

Small additional change in behavior that may have been a (slight) bug: the value passed to `rustc` by `apply_args` used to pass `auto` if that was specified by the user or would just do the `auto` logic if it `--color` was not specified at all.