### PR TITLE
Ignore leading double colon on selector arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(
     // We support older compilers
+    clippy::manual_strip,
     clippy::match_like_matches_macro,
 )]
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -115,7 +115,7 @@ pub struct Args {
     pub themes: bool,
 
     /// Local path to module or other named item to expand, e.g. os::unix::ffi
-    #[structopt(value_name = "ITEM")]
+    #[structopt(value_name = "ITEM", parse(try_from_str = parse_selector))]
     pub item: Option<Selector>,
 }
 
@@ -150,5 +150,13 @@ impl Display for Coloring {
             Coloring::Never => "never",
         };
         formatter.write_str(name)
+    }
+}
+
+fn parse_selector(s: &str) -> Result<Selector, <Selector as FromStr>::Err> {
+    if s.starts_with("::") {
+        s[2..].parse()
+    } else {
+        s.parse()
     }
 }


### PR DESCRIPTION
Previously:

<pre>
$  <b>cargo expand ::module</b>
error: Invalid value for '&lt;ITEM&gt;': Invalid path segment: `` is not an identifier
</pre>

The FromStr impl in the syn-select library is just splitting on `::` and parsing each element as an Ident.