### PR TITLE
Run a CI build on newest nightly, even if rustfmt is delayed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
   schedule: [cron: "40 1 * * *"]
 
 jobs:
-  nightly:
-    name: Rust nightly
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [beta, stable, 1.44.0]
+        rust: [nightly, beta, stable, 1.44.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
For example currently the most recent nightly is nightly-2021-02-07 so the `build` build runs with that, but rustfmt is broken on it and not shipped by rustup (https://rust-lang-nursery.github.io/rust-toolstate/). The most recent nightly on which rustfmt is available is nightly-2021-01-31 so the `test` build runs with that.