### PR TITLE
Support bat paging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_yaml",
+ "shell-words",
  "syntect",
  "unicode-width",
 ]
@@ -756,6 +757,12 @@ dependencies = [
  "serde",
  "yaml-rust",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
 name = "snailquote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ toolchain_find = "0.2"
 [dependencies.bat]
 version = "0.18"
 default-features = false
-features = ["regex-fancy"]
+features = ["regex-fancy", "paging"]
 
 [dependencies.syn]
 version = "1.0"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ setting:
 color = "always"
 ```
 
+Enable paging of the output with the `pager` setting:
+
+```toml
+[expand]
+pager = true
+```
+
 ## Disclaimer
 
 Be aware that macro expansion to text is a lossy process. This is a debugging

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,8 @@ struct Sections {
 pub struct Config {
     pub theme: Option<String>,
     pub color: Option<String>,
+    #[serde(default = "bool::default")]
+    pub pager: bool,
 }
 
 pub fn deserialize() -> Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use std::str::FromStr;
 
 use atty::Stream::{Stderr, Stdout};
 use bat::assets::HighlightingAssets;
-use bat::PrettyPrinter;
+use bat::{PagingMode, PrettyPrinter};
 use quote::quote;
 use structopt::StructOpt;
 use termcolor::{Color::Green, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -249,6 +249,9 @@ fn cargo_expand() -> Result<i32> {
             .grid(false);
         if let Some(theme) = theme {
             pretty_printer.theme(theme);
+        }
+        if config.pager {
+            pretty_printer.paging_mode(PagingMode::QuitIfOneScreen);
         }
 
         // Ignore any errors.


### PR DESCRIPTION
I often find myself using `cargo-expand` with something like `cargo expand [...] | less` or `cargo expand [...] | bat`, so I figured adding support for this could be a good idea!

This just reuses `bat`'s default paging behavior, if enabled. The setting is disabled by default for users who wouldn't want this, for some reason!

Let me know if you think this isn't something that should be merged as is