### PR TITLE
Update --pretty=expanded to -Zunpretty=expanded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-expand"
 version = "1.0.7"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 license = "MIT OR Apache-2.0"
-description = "Wrapper around rustc --pretty=expanded. Shows the result of macro expansion and #[derive] expansion."
+description = "Wrapper around rustc -Zunpretty=expanded. Shows the result of macro expansion and #[derive] expansion."
 repository = "https://github.com/dtolnay/cargo-expand"
 documentation = "https://github.com/dtolnay/cargo-expand"
 keywords = ["cargo", "subcommand", "expanded"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ cargo expand
 This is a wrapper around the more verbose compiler command:
 
 ```console
-$ cargo rustc --profile=check -- -Zunstable-options --pretty=expanded
+$ cargo rustc --profile=check -- -Zunpretty=expanded
 ```
 
 ## Installation

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,8 +385,7 @@ fn apply_args(cmd: &mut Command, args: &Args, color: &Coloring, outfile: &Path) 
 
     line.arg("-o");
     line.arg(outfile);
-    line.arg("-Zunstable-options");
-    line.arg("--pretty=expanded");
+    line.arg("-Zunpretty=expanded");
 
     if args.verbose {
         let mut display = line.clone();


### PR DESCRIPTION
`--pretty` is gone as of https://github.com/rust-lang/rust/pull/83491.