### PR TITLE
Discard a reworded Cargo stderr message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -443,6 +443,7 @@ fn ignore_cargo_err(line: &str) -> bool {
          output file name will be adapted for each output type",
         "warning emitted",
         "warnings emitted",
+        ") generated ",
     ];
     for s in &discarded_lines {
         if line.contains(s) {


### PR DESCRIPTION
The new message is like:

```console
warning: `testing` (bin "testing") generated 2 warnings
```

or:

```console
warning: `anyhow` (lib) generated 2 warnings
```