### PR TITLE
Support NO_COLOR environment variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -459,6 +459,10 @@ fn get_color(args: &Args, config: &Config) -> Coloring {
         return value;
     }
 
+    if env::var_os("NO_COLOR").is_some() {
+        return Coloring::Never;
+    }
+
     if let Some(value) = config.color.as_ref() {
         match Coloring::from_str(value.as_str()) {
             Ok(color) => return color,


### PR DESCRIPTION
Per [no-color.org](https://no-color.org), support the NO_COLOR environment variable to disable output coloration.
This is hard to configure otherwise, as a simple shell alias is not enough since `cargo` is
used to invoke `cargo-expand`.

Motivation: I prefer a lack of syntax highlighting, and I have to use `--color=never` anyway with my light theme:
![image](https://user-images.githubusercontent.com/88726114/130737946-bb65c328-a161-410e-9cb0-6d22fae54558.png)
