### PR TITLE
Work around syntect regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/install@cargo-outdated
       - run: cargo update
-      - run: cargo outdated --exit-code 1
+      - run: cargo outdated --exit-code 1 --ignore syntect

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "serde",
  "syn",
  "syn-select",
+ "syntect",
  "tempfile",
  "termcolor",
  "toml",
@@ -474,6 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,10 +527,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.9.0"
+name = "onig"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "67ddfe2c93bb389eea6e6d713306880c7f6dcc99a75b659ce145d962c861b225"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "libc",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd3eee045c84695b53b20255bb7317063df090b68e18bfac0abb6c39cf7f33e"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -551,6 +574,12 @@ checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "plist"
@@ -829,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "4.7.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9c431748126d4e82a8ee28a29fddcc276357ebb9a67d01175633b307413496"
+checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
 dependencies = [
  "bincode",
  "bitflags",
@@ -839,7 +868,8 @@ dependencies = [
  "flate2",
  "fnv",
  "lazy_static",
- "once_cell",
+ "lazycell",
+ "onig",
  "plist",
  "regex-syntax",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,28 +527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "onig"
-version = "6.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ddfe2c93bb389eea6e6d713306880c7f6dcc99a75b659ce145d962c861b225"
-dependencies = [
- "bitflags",
- "lazy_static",
- "libc",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd3eee045c84695b53b20255bb7317063df090b68e18bfac0abb6c39cf7f33e"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,12 +552,6 @@ checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "plist"
@@ -869,7 +841,6 @@ dependencies = [
  "fnv",
  "lazy_static",
  "lazycell",
- "onig",
  "plist",
  "regex-syntax",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ proc-macro2 = "1.0"
 quote = { version = "1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 syn-select = "0.2"
-syntect = "=4.6.0" # work around https://github.com/trishume/syntect/issues/402
 tempfile = "3.0"
 termcolor = "1.0"
 toml = "0.5"
@@ -34,6 +33,11 @@ features = ["paging", "regex-fancy"]
 version = "1.0"
 default-features = false
 features = ["full", "parsing", "printing", "visit-mut"]
+
+[dependencies.syntect]
+# work around https://github.com/trishume/syntect/issues/402
+version = "=4.6.0"
+default-features = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro2 = "1.0"
 quote = { version = "1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 syn-select = "0.2"
+syntect = "=4.6.0" # work around https://github.com/trishume/syntect/issues/402
 tempfile = "3.0"
 termcolor = "1.0"
 toml = "0.5"


### PR DESCRIPTION
https://github.com/dtolnay/cargo-expand/pull/123 is needed after all, since syntect 4.7.1 is also broken. See https://github.com/trishume/syntect/issues/402.

```console
$ cargo install cargo-expand

$ cargo expand
   Compiling proc-macro2 v1.0.36
    Finished dev [unoptimized + debuginfo] target(s) in 0.44s

memory allocation of 7881122326526296064 bytes failed
Aborted (core dumped)
```