### PR TITLE
Update to clap 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false
 
 [dependencies]
 atty = "0.2"
-clap = { version = "3.0", default-features = false, features = ["derive", "std", "suggestions"] }
+clap = { version = "3.1", default-features = false, features = ["derive", "std", "suggestions"] }
 prettyplease = { version = "0.1", optional = true }
 proc-macro2 = "1.0"
 quote = { version = "1.0", default-features = false }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -13,7 +13,7 @@ pub enum Opts {
         version,
         author,
         setting = AppSettings::DeriveDisplayOrder,
-        setting = AppSettings::DontCollapseArgsInUsage
+        dont_collapse_args_in_usage = true
     )]
     Expand(Args),
 }
@@ -165,5 +165,5 @@ fn parse_selector(s: &str) -> Result<Selector, <Selector as FromStr>::Err> {
 
 #[test]
 fn test_cli() {
-    <Opts as clap::IntoApp>::into_app().debug_assert();
+    <Opts as clap::CommandFactory>::command().debug_assert();
 }


### PR DESCRIPTION
There are several deprecations in this release:
https://github.com/clap-rs/clap/releases/tag/v3.1.0