### PR TITLE
Accept flag without value where `cargo rustc` does a dedicated error message

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -19,6 +19,15 @@ impl Line {
         self.args.push(arg.as_ref().to_owned());
     }
 
+    pub fn args<I, S>(&mut self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.args
+            .extend(args.into_iter().map(|arg| arg.as_ref().to_owned()));
+    }
+
     pub fn insert<S: AsRef<OsStr>>(&mut self, index: usize, arg: S) {
         self.args.insert(index, arg.as_ref().to_owned());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
     clippy::match_like_matches_macro,
     clippy::needless_pass_by_value,
     clippy::non_ascii_literal,
+    clippy::option_option,
     clippy::struct_excessive_bools,
     clippy::too_many_lines,
     clippy::trivially_copy_pass_by_ref

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,22 +348,22 @@ fn apply_args(cmd: &mut Command, args: &Args, color: &Coloring, outfile: &Path) 
 
     if let Some(bin) = &args.bin {
         line.arg("--bin");
-        line.arg(bin);
+        line.args(bin);
     }
 
     if let Some(example) = &args.example {
         line.arg("--example");
-        line.arg(example);
+        line.args(example);
     }
 
     if let Some(test) = &args.test {
         line.arg("--test");
-        line.arg(test);
+        line.args(test);
     }
 
     if let Some(bench) = &args.bench {
         line.arg("--bench");
-        line.arg(bench);
+        line.args(bench);
     }
 
     if let Some(target) = &args.target {
@@ -383,7 +383,7 @@ fn apply_args(cmd: &mut Command, args: &Args, color: &Coloring, outfile: &Path) 
 
     if let Some(package) = &args.package {
         line.arg("--package");
-        line.arg(package);
+        line.args(package);
     }
 
     if let Some(jobs) = args.jobs {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -37,24 +37,24 @@ pub struct Args {
     pub lib: bool,
 
     /// Expand only the specified binary
-    #[clap(long, value_name = "NAME")]
-    pub bin: Option<String>,
+    #[clap(long, value_name = "NAME", min_values = 0, multiple_values = false)]
+    pub bin: Option<Option<String>>,
 
     /// Expand only the specified example
-    #[clap(long, value_name = "NAME")]
-    pub example: Option<String>,
+    #[clap(long, value_name = "NAME", min_values = 0, multiple_values = false)]
+    pub example: Option<Option<String>>,
 
     /// Expand only the specified test target
-    #[clap(long, value_name = "NAME")]
-    pub test: Option<String>,
+    #[clap(long, value_name = "NAME", min_values = 0, multiple_values = false)]
+    pub test: Option<Option<String>>,
 
     /// Include tests when expanding the lib or bin
     #[clap(long)]
     pub tests: bool,
 
     /// Expand only the specified bench target
-    #[clap(long, value_name = "NAME")]
-    pub bench: Option<String>,
+    #[clap(long, value_name = "NAME", min_values = 0, multiple_values = false)]
+    pub bench: Option<Option<String>>,
 
     /// Target triple which compiles will be for
     #[clap(long, value_name = "TARGET")]
@@ -69,8 +69,14 @@ pub struct Args {
     pub manifest_path: Option<PathBuf>,
 
     /// Package to expand
-    #[clap(short, long, value_name = "SPEC")]
-    pub package: Option<String>,
+    #[clap(
+        short,
+        long,
+        value_name = "SPEC",
+        min_values = 0,
+        multiple_values = false
+    )]
+    pub package: Option<Option<String>>,
 
     /// Build artifacts in release mode, with optimizations
     #[clap(long)]


### PR DESCRIPTION
Before:

```console
$ cargo expand --test
error: The argument '--test <NAME>' requires a value but none was supplied

USAGE:
    cargo expand [OPTIONS] [ITEM]

For more information try --help
```

After:

```console
$ cargo expand --test
error: "--test" takes one argument.
Available tests:
    compiletest
    test_autotrait
    test_backtrace
    test_boxed
    test_chain
    test_context
    test_convert
    test_downcast
    test_ensure
    test_ffi
    test_fmt
    test_macros
    test_repr
    test_source
```