### PR TITLE
Add subcommand metadata so `cargo --list` can print a description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ version = "1.0.19"
 dependencies = [
  "atty",
  "bat",
+ "cargo-subcommand-metadata",
  "clap",
  "prettyplease",
  "proc-macro2",
@@ -162,6 +163,12 @@ dependencies = [
 [[package]]
 name = "cargo-expand-test"
 version = "0.0.0"
+
+[[package]]
+name = "cargo-subcommand-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ autotests = false
 
 [dependencies]
 atty = "0.2"
+cargo-subcommand-metadata = "0.1"
 clap = { version = "3.1", default-features = false, features = ["derive", "std", "suggestions"] }
 prettyplease = { version = "0.1", optional = true }
 proc-macro2 = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ use std::str::FromStr;
 use std::thread::Result as ThreadResult;
 use termcolor::{Color::Green, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
+cargo_subcommand_metadata::description!("Show result of macro expansion");
+
 fn main() {
     let result = cargo_expand_or_run_nightly();
     process::exit(match result {


### PR DESCRIPTION
- https://github.com/rust-lang/cargo/issues/10662
- https://github.com/rust-lang/cargo/pull/10663