### PR TITLE
Use `PrettyPrinter::themes()` instead of internal `bat` API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,6 @@ use crate::error::Result;
 use crate::opts::Coloring::*;
 use crate::opts::{Args, Coloring, Opts};
 use atty::Stream::{Stderr, Stdout};
-use bat::assets::HighlightingAssets;
 use bat::{PagingMode, PrettyPrinter};
 use clap::Parser;
 use quote::quote;
@@ -128,7 +127,7 @@ fn cargo_expand() -> Result<i32> {
     let config = config::deserialize();
 
     if args.themes {
-        for theme in HighlightingAssets::from_binary().themes() {
+        for theme in PrettyPrinter::new().themes() {
             let _ = writeln!(io::stdout(), "{}", theme);
         }
         return Ok(0);


### PR DESCRIPTION
The bat project have started to look into what it would take to release bat v1.0. As part of that work I am going through the API usage of our clients.

I noticed that `cargo-expand` is using what is considered an internal/unstable `bat` API, namely `HighlightingAssets`. This PR replaces the `HighlightingAssets` usage with an API call that is considered future-proof.