### PR TITLE
Parse color setting as ValueEnum

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use crate::opts::Coloring::*;
 use crate::opts::{Args, Coloring, Opts};
 use atty::Stream::{Stderr, Stdout};
 use bat::{PagingMode, PrettyPrinter};
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use quote::quote;
 use std::env;
 use std::ffi::OsString;
@@ -39,7 +39,6 @@ use std::panic::{self, PanicInfo, UnwindSafe};
 use std::path::{Path, PathBuf};
 use std::process::{self, Command, Stdio};
 use std::ptr;
-use std::str::FromStr;
 use std::thread::Result as ThreadResult;
 use termcolor::{Color::Green, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
@@ -404,7 +403,7 @@ fn apply_args(cmd: &mut Command, args: &Args, color: &Coloring, outfile: &Path) 
         } else {
             "never"
         }),
-        color => line.arg(color.to_string()),
+        color => line.arg(color.to_possible_value().unwrap().get_name()),
     }
 
     if args.frozen {
@@ -529,7 +528,8 @@ fn get_color(args: &Args, config: &Config) -> Coloring {
     }
 
     if let Some(value) = config.color.as_ref() {
-        match Coloring::from_str(value.as_str()) {
+        let ignore_case = false;
+        match Coloring::from_str(value.as_str(), ignore_case) {
             Ok(color) => return color,
             Err(err) => {
                 let _ = writeln!(

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,5 +1,4 @@
-use clap::Parser;
-use std::fmt::{self, Display};
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 use std::str::FromStr;
 use syn_select::Selector;
@@ -121,38 +120,11 @@ pub struct Args {
     pub item: Option<Selector>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(ValueEnum, Debug, Clone, Copy)]
 pub enum Coloring {
     Auto,
     Always,
     Never,
-}
-
-impl FromStr for Coloring {
-    type Err = String;
-
-    fn from_str(name: &str) -> Result<Self, Self::Err> {
-        match name {
-            "auto" => Ok(Coloring::Auto),
-            "always" => Ok(Coloring::Always),
-            "never" => Ok(Coloring::Never),
-            other => Err(format!(
-                "must be auto, always, or never, but found `{}`",
-                other,
-            )),
-        }
-    }
-}
-
-impl Display for Coloring {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let name = match self {
-            Coloring::Auto => "auto",
-            Coloring::Always => "always",
-            Coloring::Never => "never",
-        };
-        formatter.write_str(name)
-    }
 }
 
 fn parse_selector(s: &str) -> Result<Selector, <Selector as FromStr>::Err> {


### PR DESCRIPTION
This produces nicer errors.

**Before:**

```console
$ cargo expand --color=alway
error: Invalid value 'alway' for '--color <WHEN>': must be auto, always, or never, but found `alway`

For more information try '--help'
```

**After:**

```console
$ cargo expand --color=alway
error: 'alway' isn't a valid value for '--color <WHEN>'
  [possible values: auto, always, never]

  Did you mean 'always'?

For more information try '--help'
```