### PR TITLE
Support expanding tests in release mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,11 @@ fn apply_args(cmd: &mut Command, args: &Expand, color: &Coloring, outfile: &Path
     if let Some(profile) = &args.profile {
         line.arg(profile);
     } else if args.tests && args.test.is_none() {
-        line.arg("test");
+        if args.release {
+            line.arg("bench");
+        } else {
+            line.arg("test");
+        }
     } else if args.release {
         line.arg("release");
     } else {


### PR DESCRIPTION
```rust
// lib.rs

// cargo expand
#[cfg(all(not(test), debug_assertions))]
const PROFILE: &str = "debug";

// cargo expand --release
#[cfg(all(not(test), not(debug_assertions)))]
const PROFILE: &str = "release";

// cargo expand --tests --lib
#[cfg(all(test, debug_assertions))]
const PROFILE: &str = "test debug";

// cargo expand --tests --lib --release
#[cfg(all(test, not(debug_assertions)))]
const PROFILE: &str = "test release";
```

See #172.