### PR TITLE
Switch from atty crate to is-terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,10 +177,10 @@ checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 name = "cargo-expand"
 version = "1.0.46"
 dependencies = [
- "atty",
  "bat",
  "cargo-subcommand-metadata",
  "clap",
+ "is-terminal",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ default = ["prettyplease"]
 prettyplease = []
 
 [dependencies]
-atty = "0.2"
 bat = { version = "0.23", default-features = false, features = ["paging", "regex-fancy"] }
 cargo-subcommand-metadata = "0.1"
 clap = { version = "4", features = ["deprecated", "derive"] }
+is-terminal = "0.4"
 prettyplease = { version = "0.2.4", features = ["verbatim"] }
 proc-macro2 = "1.0"
 quote = { version = "1.0", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,9 @@ use crate::config::Config;
 use crate::error::Result;
 use crate::opts::Coloring::*;
 use crate::opts::{Coloring, Expand, Subcommand};
-use atty::Stream::{Stderr, Stdout};
 use bat::{PagingMode, PrettyPrinter};
 use clap::{Parser, ValueEnum};
+use is_terminal::IsTerminal;
 use quote::quote;
 use std::env;
 use std::ffi::OsString;
@@ -271,7 +271,7 @@ fn cargo_expand() -> Result<i32> {
     let do_color = match color {
         Always => true,
         Never => false,
-        Auto => !none_theme && atty::is(Stdout),
+        Auto => !none_theme && io::stdout().is_terminal(),
     };
     let _ = writeln!(io::stderr());
     if do_color {
@@ -401,7 +401,7 @@ fn apply_args(cmd: &mut Command, args: &Expand, color: &Coloring, outfile: &Path
 
     line.arg("--color");
     match color {
-        Coloring::Auto => line.arg(if cfg!(not(windows)) && atty::is(Stderr) {
+        Coloring::Auto => line.arg(if cfg!(not(windows)) && io::stderr().is_terminal() {
             "always"
         } else {
             "never"


### PR DESCRIPTION
`atty` is unmaintained. Cargo and numerous other projects have switched to `is-terminal`.