### PR TITLE
Follow the `default-run` field in 'Cargo.toml' just like `cargo run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,11 +186,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-expand"
 version = "1.0.59"
 dependencies = [
  "bat",
  "cargo-subcommand-metadata",
+ "cargo_metadata",
  "clap",
  "is-terminal",
  "prettyplease",
@@ -210,10 +220,33 @@ name = "cargo-expand-test"
 version = "0.0.0"
 
 [[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-subcommand-metadata"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cc"
@@ -867,6 +900,9 @@ name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ prettyplease = []
 [dependencies]
 bat = { version = "0.23", default-features = false, features = ["paging", "regex-fancy"] }
 cargo-subcommand-metadata = "0.1"
+cargo_metadata = "0.15.4"
 clap = { version = "4", features = ["deprecated", "derive"] }
 is-terminal = "0.4"
 prettyplease = { version = "0.2.9", features = ["verbatim"] }


### PR DESCRIPTION
fix #184 Follow the `default-run` field in 'Cargo.toml' just like `cargo run`
