### PR TITLE
Work around clap's implementation of subcommand version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use crate::opts::Coloring::*;
 use crate::opts::{Coloring, Expand, Subcommand};
 use crate::unparse::unparse_maximal;
 use bat::{PagingMode, PrettyPrinter};
-use clap::{Parser, ValueEnum};
+use clap::{CommandFactory, Parser, ValueEnum};
 use quote::quote;
 use std::env;
 use std::ffi::OsString;
@@ -62,6 +62,13 @@ fn cargo_binary() -> OsString {
 
 fn cargo_expand() -> Result<i32> {
     let Subcommand::Expand(args) = Subcommand::parse();
+
+    if args.version {
+        let mut stdout = io::stdout();
+        let _ = stdout.write_all(Subcommand::command().render_version().as_bytes());
+        return Ok(0);
+    }
+
     let config = config::deserialize();
 
     if args.themes {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -9,7 +9,7 @@ const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
 #[command(bin_name = "cargo", version = VERSION, author, disable_help_subcommand = true)]
 pub enum Subcommand {
     /// Show the result of macro expansion.
-    #[command(name = "expand", version = VERSION, author)]
+    #[command(name = "expand", version = VERSION, author, disable_version_flag = true)]
     Expand(Expand),
 }
 
@@ -118,6 +118,10 @@ pub struct Expand {
     /// Local path to module or other named item to expand, e.g. os::unix::ffi
     #[arg(value_name = "ITEM", value_parser = parse_selector)]
     pub item: Option<Selector>,
+
+    /// Print version
+    #[arg(long)]
+    pub version: bool,
 }
 
 #[derive(ValueEnum, Debug, Clone, Copy)]


### PR DESCRIPTION
Previously, `cargo expand --version` would print "cargo-expand-expand #.#.#" due to https://github.com/clap-rs/clap/issues/1382. Now it will print "cargo-expand #.#.#".