### PR TITLE
Make prettyplease version appear only if `--version --verbose` is used

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,14 +5,12 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
-    let mut version = env!("CARGO_PKG_VERSION").to_owned();
-    if let Ok(prettyplease_version) = env::var("DEP_PRETTYPLEASE02_VERSION") {
-        // TODO: Make this appear only if `--version --verbose` is used.
-        version.push_str(" + prettyplease ");
-        version.push_str(&prettyplease_version);
-    }
+    let prettyplease_version = match env::var("DEP_PRETTYPLEASE02_VERSION") {
+        Ok(prettyplease_version) => format!(r#"Some("{}")"#, prettyplease_version.escape_debug()),
+        Err(_) => "None".to_owned(),
+    };
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let version_file = out_dir.join("version");
-    fs::write(version_file, version).unwrap();
+    let prettyplease_version_file = out_dir.join("prettyplease.version");
+    fs::write(prettyplease_version_file, prettyplease_version).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod fmt;
 mod manifest;
 mod opts;
 mod unparse;
+mod version;
 
 use crate::cmd::Line;
 use crate::config::Config;
@@ -29,8 +30,9 @@ use crate::error::Result;
 use crate::opts::Coloring::*;
 use crate::opts::{Coloring, Expand, Subcommand};
 use crate::unparse::unparse_maximal;
+use crate::version::Version;
 use bat::{PagingMode, PrettyPrinter};
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{Parser, ValueEnum};
 use quote::quote;
 use std::env;
 use std::ffi::OsString;
@@ -64,8 +66,10 @@ fn cargo_expand() -> Result<i32> {
     let Subcommand::Expand(args) = Subcommand::parse();
 
     if args.version {
-        let mut stdout = io::stdout();
-        let _ = stdout.write_all(Subcommand::command().render_version().as_bytes());
+        let version = Version {
+            verbose: args.verbose,
+        };
+        let _ = writeln!(io::stdout(), "{}", version);
         return Ok(0);
     }
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -3,13 +3,11 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use syn_select::Selector;
 
-const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version"));
-
 #[derive(Parser)]
-#[command(bin_name = "cargo", version = VERSION, author, disable_help_subcommand = true)]
+#[command(bin_name = "cargo", version, author, disable_help_subcommand = true)]
 pub enum Subcommand {
     /// Show the result of macro expansion.
-    #[command(name = "expand", version = VERSION, author, disable_version_flag = true)]
+    #[command(name = "expand", version, author, disable_version_flag = true)]
     Expand(Expand),
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,23 @@
+use std::fmt::{self, Display};
+
+const CARGO_EXPAND_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PRETTYPLEASE_VERSION: Option<&str> =
+    include!(concat!(env!("OUT_DIR"), "/prettyplease.version"));
+
+pub(crate) struct Version {
+    pub verbose: bool,
+}
+
+impl Display for Version {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("cargo-expand ")?;
+        formatter.write_str(CARGO_EXPAND_VERSION)?;
+        if self.verbose {
+            if let Some(prettyplease_version) = PRETTYPLEASE_VERSION {
+                formatter.write_str(" + prettyplease ")?;
+                formatter.write_str(prettyplease_version)?;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #154.