### PR TITLE
Remove duplicated coloring values in help message

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -36,7 +36,7 @@ pub struct Expand {
     #[arg(long)]
     pub verbose: bool,
 
-    /// Coloring: auto, always, never
+    /// Coloring
     #[arg(long, value_name = "WHEN")]
     pub color: Option<Coloring>,
 


### PR DESCRIPTION
Before: The possible values for the `--color` option were duplicated in the help output:
```
      --color <WHEN>        Coloring: auto, always, never [possible values: auto, always, never]
```

With this change, this duplication is removed:
```
      --color <WHEN>        Coloring [possible values: auto, always, never]
```