### PR TITLE
Add short features flag

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -81,7 +81,7 @@ pub struct Expand {
     pub bench: Option<Option<String>>,
 
     /// Space or comma separated list of features to activate
-    #[arg(long, value_name = "FEATURES", help_heading = FEATURE_SELECTION)]
+    #[arg(short = 'F', long, value_name = "FEATURES", help_heading = FEATURE_SELECTION)]
     pub features: Option<String>,
 
     /// Activate all available features


### PR DESCRIPTION
Cargo added a short flag `-F` for `--features` in https://github.com/rust-lang/cargo/pull/10576. This adds it here to keep it in sync with cargo's interface.
