### PR TITLE
Respect pre-existing RUSTC_BOOTSTRAP setting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -410,6 +410,10 @@ fn apply_args(cmd: &mut Command, args: &Expand, color: &Coloring, outfile: &Path
 }
 
 fn needs_rustc_bootstrap() -> bool {
+    if env::var_os("RUSTC_BOOTSTRAP").is_some_and(|var| !var.is_empty()) {
+        return false;
+    }
+
     let rustc = if let Some(rustc) = env::var_os("RUSTC") {
         PathBuf::from(rustc)
     } else {


### PR DESCRIPTION
This avoids overwriting RUSTC_BOOTSTRAP=1 in the case of `RUSTC_BOOTSTRAP=some,crates cargo +stable expand`, which caused crates which do `cargo:rerun-if-env-changed=RUSTC_BOOTSTRAP` to recompile unnecessarily.

If the name of the crate currently being expanded is not listed in the pre-existing value of RUSTC_BOOTSTRAP, the expand command will fail.

```console
error: the option `Z` is only accepted on the nightly compiler
help: consider switching to a nightly toolchain: `rustup default nightly`
note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>
note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>
error: 1 nightly option were parsed
```