### PR TITLE
Use fs-err to improve error messages on filesystem operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +182,7 @@ dependencies = [
  "bat",
  "cargo-subcommand-metadata",
  "clap",
+ "fs-err",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -364,6 +371,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "globset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ prettyplease = []
 bat = { version = "0.24", default-features = false, features = ["paging", "regex-fancy"] }
 cargo-subcommand-metadata = "0.1"
 clap = { version = "4", features = ["deprecated", "derive"] }
+fs-err = "2"
 prettyplease = { version = "0.2.17", features = ["verbatim"] }
 proc-macro2 = "1.0.74"
 quote = { version = "1.0.35", default-features = false }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
 use std::env;
-use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
@@ -35,7 +34,7 @@ fn try_deserialize() -> Option<Config> {
         .map(|name| cargo_home.join(name))
         .find(|path| path.exists())?;
 
-    let content = fs::read_to_string(&config_path).ok()?;
+    let content = fs_err::read_to_string(&config_path).ok()?;
 
     let full_config: Sections = match toml::from_str(&content) {
         Ok(config) => config,

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,6 +1,5 @@
 use crate::error::Result;
 use serde::Serialize;
-use std::fs;
 use std::path::Path;
 
 #[derive(Serialize)]
@@ -20,7 +19,7 @@ pub fn write_rustfmt_config(outdir: impl AsRef<Path>) -> Result<()> {
     let toml_string = toml::to_string(&config)?;
 
     let rustfmt_config_path = outdir.as_ref().join("rustfmt.toml");
-    fs::write(rustfmt_config_path, toml_string)?;
+    fs_err::write(rustfmt_config_path, toml_string)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ use quote::quote;
 use std::env;
 use std::error::Error as StdError;
 use std::ffi::OsString;
-use std::fs;
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::panic::{self, PanicInfo, UnwindSafe};
 use std::path::{Path, PathBuf};
@@ -133,7 +132,7 @@ fn cargo_expand() -> Result<i32> {
         return Ok(1);
     }
 
-    let mut content = fs::read_to_string(&outfile_path)?;
+    let mut content = fs_err::read_to_string(&outfile_path)?;
     if content.is_empty() {
         let _ = writeln!(io::stderr(), "ERROR: rustc produced no expanded output");
         return Ok(if code == 0 { 1 } else { code });
@@ -188,7 +187,7 @@ fn cargo_expand() -> Result<i32> {
 
         if let Some(unformatted) = to_rustfmt {
             if let Some(rustfmt) = rustfmt.or_else(which_rustfmt) {
-                fs::write(&outfile_path, unformatted)?;
+                fs_err::write(&outfile_path, unformatted)?;
 
                 fmt::write_rustfmt_config(&outdir)?;
 
@@ -201,7 +200,7 @@ fn cargo_expand() -> Result<i32> {
                         .output();
                     if let Ok(output) = output {
                         if output.status.success() {
-                            stage = Stage::Formatted(fs::read_to_string(&outfile_path)?);
+                            stage = Stage::Formatted(fs_err::read_to_string(&outfile_path)?);
                             break;
                         }
                     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,7 +1,6 @@
 use crate::error::Result;
 use serde::Deserialize;
 use std::env;
-use std::fs;
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 
@@ -18,7 +17,7 @@ pub struct CargoPackage {
 
 pub fn parse(manifest_path: Option<&Path>) -> Result<CargoManifest> {
     let manifest_path = find_cargo_manifest(manifest_path)?;
-    let content = fs::read_to_string(manifest_path)?;
+    let content = fs_err::read_to_string(manifest_path)?;
     let cargo_manifest: CargoManifest = toml::from_str(&content)?;
     Ok(cargo_manifest)
 }


### PR DESCRIPTION
Before:

```console
No such file or directory (os error 2)
```

After:

```console
failed to open file `/tmp/cargo-expandvDuC7E/expanded`

Caused by:
  No such file or directory (os error 2)
```