### PR TITLE
Skip cargo test in most CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       - run: cargo test
         env:
           RUSTFLAGS: ${{env.RUSTFLAGS}} ${{matrix.rust == 'nightly' && '--cfg exhaustive' || ''}}
+        if: matrix.os == 'ubuntu' && matrix.rust == 'nightly'
 
   clippy:
     name: Clippy


### PR DESCRIPTION
The new jobs from #214 are significantly slower than the previously existing ones.

<p align="center"><img src="https://github.com/dtolnay/cargo-expand/assets/1940490/95243649-9dba-4928-872c-bfcfc977833e" width="300"></p>

The only use of `cargo test` currently is this one test:

https://github.com/dtolnay/cargo-expand/blob/db00234ff5d9133691ca8a05f4a2d84ab71743ed/src/opts.rs#L151-L154

which it's sufficient to cover on one platform only.