### PR TITLE
Disregard empty RUSTC_WRAPPER

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ fn do_cargo_expand() -> Result<i32> {
 
     if needs_rustc_bootstrap() {
         if let Ok(current_exe) = env::current_exe() {
-            let original_wrapper = env::var_os("RUSTC_WRAPPER");
+            let original_wrapper =
+                env::var_os("RUSTC_WRAPPER").filter(|wrapper| !wrapper.is_empty());
             let wrapper = original_wrapper.as_deref().unwrap_or(OsStr::new("/"));
             cmd.env(CARGO_EXPAND_RUSTC_WRAPPER, wrapper);
             cmd.env("RUSTC_WRAPPER", current_exe);


### PR DESCRIPTION
`RUSTC_WRAPPER=` is supposed to mean the same as unset RUSTC_WRAPPER.

**Before:**

```console
$ RUSTC_WRAPPER= cargo +stable expand
error: failed to run `rustc` to learn about target-specific information
Caused by:
  process didn't exit successfully: `~/.cargo/bin/cargo-expand ~/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc - --crate-name ___ --print=file-names --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  No such file or directory (os error 2)
```

**After:** works.