### PR TITLE
Preserve doc attributes on statements

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,12 +1,5 @@
 use syn::visit_mut::{self, VisitMut};
-use syn::{
-    Attribute, Block, Expr, ExprArray, ExprAssign, ExprAsync, ExprAwait, ExprBinary, ExprBlock,
-    ExprBreak, ExprCall, ExprCast, ExprClosure, ExprConst, ExprContinue, ExprField, ExprForLoop,
-    ExprGroup, ExprIf, ExprIndex, ExprInfer, ExprLet, ExprLit, ExprLoop, ExprMacro, ExprMatch,
-    ExprMethodCall, ExprParen, ExprPath, ExprRange, ExprRawAddr, ExprReference, ExprRepeat,
-    ExprReturn, ExprStruct, ExprTry, ExprTryBlock, ExprTuple, ExprUnary, ExprUnsafe, ExprWhile,
-    ExprYield, File, Item, ItemMod, Stmt,
-};
+use syn::{Block, File, Item, ItemMod, Stmt};
 
 pub fn sanitize(syntax_tree: &mut File) {
     remove_macro_rules_from_vec_item(&mut syntax_tree.items);
@@ -32,20 +25,6 @@ impl VisitMut for Sanitize {
         });
         visit_mut::visit_block_mut(self, i);
     }
-
-    fn visit_stmt_mut(&mut self, i: &mut Stmt) {
-        match i {
-            Stmt::Local(local) => remove_doc_attributes(&mut local.attrs),
-            Stmt::Expr(e, _semi) => {
-                if let Some(attrs) = attrs_mut(e) {
-                    remove_doc_attributes(attrs);
-                }
-            }
-            Stmt::Item(_) => {}
-            Stmt::Macro(mac) => remove_doc_attributes(&mut mac.attrs),
-        }
-        visit_mut::visit_stmt_mut(self, i);
-    }
 }
 
 fn remove_macro_rules_from_vec_item(items: &mut Vec<Item>) {
@@ -53,56 +32,4 @@ fn remove_macro_rules_from_vec_item(items: &mut Vec<Item>) {
         Item::Macro(_) => false,
         _ => true,
     });
-}
-
-fn remove_doc_attributes(attrs: &mut Vec<Attribute>) {
-    attrs.retain(|attr| !attr.path().is_ident("doc"));
-}
-
-fn attrs_mut(e: &mut Expr) -> Option<&mut Vec<Attribute>> {
-    match e {
-        #![cfg_attr(all(test, exhaustive), deny(non_exhaustive_omitted_patterns))]
-        Expr::Array(ExprArray { attrs, .. })
-        | Expr::Assign(ExprAssign { attrs, .. })
-        | Expr::Async(ExprAsync { attrs, .. })
-        | Expr::Await(ExprAwait { attrs, .. })
-        | Expr::Binary(ExprBinary { attrs, .. })
-        | Expr::Block(ExprBlock { attrs, .. })
-        | Expr::Break(ExprBreak { attrs, .. })
-        | Expr::Call(ExprCall { attrs, .. })
-        | Expr::Cast(ExprCast { attrs, .. })
-        | Expr::Closure(ExprClosure { attrs, .. })
-        | Expr::Const(ExprConst { attrs, .. })
-        | Expr::Continue(ExprContinue { attrs, .. })
-        | Expr::Field(ExprField { attrs, .. })
-        | Expr::ForLoop(ExprForLoop { attrs, .. })
-        | Expr::Group(ExprGroup { attrs, .. })
-        | Expr::If(ExprIf { attrs, .. })
-        | Expr::Index(ExprIndex { attrs, .. })
-        | Expr::Infer(ExprInfer { attrs, .. })
-        | Expr::Let(ExprLet { attrs, .. })
-        | Expr::Lit(ExprLit { attrs, .. })
-        | Expr::Loop(ExprLoop { attrs, .. })
-        | Expr::Macro(ExprMacro { attrs, .. })
-        | Expr::Match(ExprMatch { attrs, .. })
-        | Expr::MethodCall(ExprMethodCall { attrs, .. })
-        | Expr::Paren(ExprParen { attrs, .. })
-        | Expr::Path(ExprPath { attrs, .. })
-        | Expr::Range(ExprRange { attrs, .. })
-        | Expr::RawAddr(ExprRawAddr { attrs, .. })
-        | Expr::Reference(ExprReference { attrs, .. })
-        | Expr::Repeat(ExprRepeat { attrs, .. })
-        | Expr::Return(ExprReturn { attrs, .. })
-        | Expr::Struct(ExprStruct { attrs, .. })
-        | Expr::Try(ExprTry { attrs, .. })
-        | Expr::TryBlock(ExprTryBlock { attrs, .. })
-        | Expr::Tuple(ExprTuple { attrs, .. })
-        | Expr::Unary(ExprUnary { attrs, .. })
-        | Expr::Unsafe(ExprUnsafe { attrs, .. })
-        | Expr::While(ExprWhile { attrs, .. })
-        | Expr::Yield(ExprYield { attrs, .. }) => Some(attrs),
-
-        Expr::Verbatim(_) => None,
-        _ => None,
-    }
 }


### PR DESCRIPTION
Since https://github.com/dtolnay/cargo-expand/pull/163, working around this rustfmt bug is no longer relevant to most users.