### PR TITLE
Inline bat's PrettyPrinter logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "bat",
  "cargo-subcommand-metadata",
  "clap",
+ "console",
  "fs-err",
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ prettyplease = []
 bat = { version = "0.24", default-features = false, features = ["paging", "regex-fancy"] }
 cargo-subcommand-metadata = "0.1"
 clap = { version = "4", features = ["deprecated", "derive"] }
+console = "0.15"
 fs-err = "3"
 prettyplease = { version = "0.2.25", features = ["verbatim"] }
 proc-macro2 = "1.0.80"


### PR DESCRIPTION
This should have no immediate change on behavior, but unblocks more fine-grained control over HighlightingAssets loading than what is exposed by PrettyPrinter's simplified interface.