### PR TITLE
Use cargo exit code as top-level exit code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -334,7 +334,7 @@ fn do_cargo_expand() -> Result<i32> {
         let _ = write!(io::stdout(), "{}", content);
     }
 
-    Ok(0)
+    Ok(code)
 }
 
 fn which_rustfmt() -> Option<PathBuf> {


### PR DESCRIPTION
This will cause 'cargo expand' to exit with a non-zero exit code when a compiler error occurs while expanding the file. This is useful for crates like `macrotest`, which need to detect when expansion fails.