### PR TITLE
Downgrade dependency on yanked version of deranged crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]


### PR DESCRIPTION
https://crates.io/crates/deranged/0.4.1 has been yanked, together with one commit from it being reverted: https://github.com/jhpratt/deranged/commit/94631377ec404d14ed0f2b05a2ead06f31caac03. This is causing `cargo install --locked` to report a warning.

```console
warning: package `deranged v0.4.1` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
```